### PR TITLE
v3.1.2-2 - Boost build fix

### DIFF
--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -236,7 +236,11 @@ void ofstream::close()
 }
 #else // __GLIBCXX__
 
+#if BOOST_VERSION >= 107700
+static_assert(sizeof(*BOOST_FILESYSTEM_C_STR(fs::path())) == sizeof(wchar_t),
+#else
 static_assert(sizeof(*fs::path().BOOST_FILESYSTEM_C_STR) == sizeof(wchar_t),
+#endif // BOOST_VERSION >= 107700
     "Warning: This build is using boost::filesystem ofstream and ifstream "
     "implementations which will fail to open paths containing multibyte "
     "characters. You should delete this static_assert to ignore this warning, "

--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -18,9 +18,13 @@ BOOST_AUTO_TEST_CASE(getwalletenv_file)
     std::string test_name = "test_name.dat";
     const fs::path datadir = GetDataDir();
     fs::path file_path = datadir / test_name;
-    std::ofstream f(file_path.BOOST_FILESYSTEM_C_STR);
-    f.close();
-
+    #if BOOST_VERSION >= 107700
+        std::ofstream f(BOOST_FILESYSTEM_C_STR(file_path));
+    #else
+        std::ofstream f(file_path.BOOST_FILESYSTEM_C_STR);
+    #endif // BOOST_VERSION >= 107700
+        f.close();
+    	
     std::string filename;
     std::shared_ptr<BerkeleyEnvironment> env = GetWalletEnv(file_path, filename);
     BOOST_CHECK(filename == test_name);

--- a/src/wallet/test/init_test_fixture.cpp
+++ b/src/wallet/test/init_test_fixture.cpp
@@ -32,7 +32,7 @@ InitWalletDirTestingSetup::InitWalletDirTestingSetup(const std::string& chainNam
     fs::create_directories(m_walletdir_path_cases["custom"]);
     fs::create_directories(m_walletdir_path_cases["relative"]);
     #if BOOST_VERSION >= 107700
-        Std::ofstream f(BOOST_FILESYSTEM_C_STR(m_walletdir_path_cases["file"]));
+        std::ofstream f(BOOST_FILESYSTEM_C_STR(m_walletdir_path_cases["file"]));
     #else    
 	std::ofstream f(m_walletdir_path_cases["file"].BOOST_FILESYSTEM_C_STR);
     #endif // BOOST_VERSION >= 107700

--- a/src/wallet/test/init_test_fixture.cpp
+++ b/src/wallet/test/init_test_fixture.cpp
@@ -31,16 +31,15 @@ InitWalletDirTestingSetup::InitWalletDirTestingSetup(const std::string& chainNam
     fs::create_directories(m_walletdir_path_cases["default"]);
     fs::create_directories(m_walletdir_path_cases["custom"]);
     fs::create_directories(m_walletdir_path_cases["relative"]);
-    std::ofstream f(m_walletdir_path_cases["file"].BOOST_FILESYSTEM_C_STR);
-    f.close();
+    #if BOOST_VERSION >= 107700
+        Std::ofstream f(BOOST_FILESYSTEM_C_STR(m_walletdir_path_cases["file"]));
+    #else    
+	std::ofstream f(m_walletdir_path_cases["file"].BOOST_FILESYSTEM_C_STR);
+    #endif // BOOST_VERSION >= 107700
+        f.close();
 }
 
 InitWalletDirTestingSetup::~InitWalletDirTestingSetup()
 {
     fs::current_path(m_cwd);
-}
-
-void InitWalletDirTestingSetup::SetWalletDir(const fs::path& walletdir_path)
-{
-    gArgs.ForceSetArg("-walletdir", walletdir_path.string());
 }


### PR DESCRIPTION
BOOST_FILESYSTEM_C_STR -- accept path as argument


